### PR TITLE
List and prompt

### DIFF
--- a/.ok
+++ b/.ok
@@ -2,3 +2,6 @@
 unset _OK_C_HEADING;unset _OK_C_NUMBER;unset _OK_C_COMMENT;unset _OK_C_COMMAND;unset _OK_C_PROMPT                          #Reset colors to defaults                    
 _OK_C_HEADING="[h]";_OK_C_NUMBER="[n]";_OK_C_COMMENT="[--]";_OK_C_COMMAND="[C]";_OK_C_PROMPT="[p]"                         #Change colors to text markers for debugging 
 _OK_C_HEADING=$'\033[1;30;45m';_OK_C_NUMBER=$'\033[1;33;44m';_OK_C_COMMENT=$'\033[1;34;46m';_OK_C_COMMAND=$'\033[1;37;44m' #Custom color scheme                         
+# Tests arguments passing (you can pass arguments after <number>, both at the bash-prompt and the ok-prompt)
+echo "Passed arguments: 1:[$1], 2:[$2], 3:[$3], 4+:[${@:4}] (nr args: $#)"   # Comments starts too early, clearly a bug
+echo "All passed arguments: [$@]"

--- a/.ok
+++ b/.ok
@@ -6,6 +6,7 @@ _OK_C_HEADING=$'\033[1;30;45m';_OK_C_NUMBER=$'\033[1;33;44m ';_OK_C_COMMENT=$'\0
 unset _OK_PROMPT; unset _OK_VERBOSE  # Reset to defaults                                                                       
 _OK_PROMPT="-=> "; _OK_VERBOSE=2     # Show a "nice" prompt, and give all the feedback ok can provide for                      
 _OK_PROMPT="% "; _OK_VERBOSE=0       # Show ancient prompt, and only say the most necessary (don't even show executed command) 
+
 # Tests arguments passing (you can pass arguments after <number>, both at the bash-prompt and the ok-prompt)                              
 echo "Passed arguments: 1:[$1], 2:[$2], 3:[$3], 4+:[${@:4}] (nr args: $#)" # Comment-color starts too early; clearly a bug (so better 
 echo "All passed arguments: [$@]"                                          # not to use a number sign in a command for now)...        

--- a/.ok
+++ b/.ok
@@ -2,10 +2,11 @@
 unset _OK_C_HEADING;unset _OK_C_NUMBER;unset _OK_C_COMMENT;unset _OK_C_COMMAND;unset _OK_C_PROMPT                           #Reset colors to defaults                    
 _OK_C_HEADING="[h]";_OK_C_NUMBER="[n]";_OK_C_COMMENT="[--]";_OK_C_COMMAND="[C]";_OK_C_PROMPT="[p]"                          #Change colors to text markers for debugging 
 _OK_C_HEADING=$'\033[1;30;45m';_OK_C_NUMBER=$'\033[1;33;44m ';_OK_C_COMMENT=$'\033[1;34;46m';_OK_C_COMMAND=$'\033[1;37;44m' #Custom color scheme                         
-# Tests arguments passing (you can pass arguments after <number>, both at the bash-prompt and the ok-prompt)                              
-echo "Passed arguments: 1:[$1], 2:[$2], 3:[$3], 4+:[${@:4}] (nr args: $#)" # Comment-color starts too early; clearly a bug (so better 
-echo "All passed arguments: [$@]"                                          # not to use a number sign in a command for now)...        
 # Other customizations                                                                                                             
 unset _OK_PROMPT; unset _OK_VERBOSE  # Reset to defaults                                                                       
 _OK_PROMPT="-=> "; _OK_VERBOSE=2     # Show a "nice" prompt, and give all the feedback ok can provide for                      
 _OK_PROMPT="% "; _OK_VERBOSE=0       # Show ancient prompt, and only say the most necessary (don't even show executed command) 
+# Tests arguments passing (you can pass arguments after <number>, both at the bash-prompt and the ok-prompt)                              
+echo "Passed arguments: 1:[$1], 2:[$2], 3:[$3], 4+:[${@:4}] (nr args: $#)" # Comment-color starts too early; clearly a bug (so better 
+echo "All passed arguments: [$@]"                                          # not to use a number sign in a command for now)...        
+ok help --verbose                                                          # Show help page of 🆗, including environment variables

--- a/.ok
+++ b/.ok
@@ -1,7 +1,11 @@
-# Manipulate customizations (colors)                                                                                                                                       
-unset _OK_C_HEADING;unset _OK_C_NUMBER;unset _OK_C_COMMENT;unset _OK_C_COMMAND;unset _OK_C_PROMPT                          #Reset colors to defaults                    
-_OK_C_HEADING="[h]";_OK_C_NUMBER="[n]";_OK_C_COMMENT="[--]";_OK_C_COMMAND="[C]";_OK_C_PROMPT="[p]"                         #Change colors to text markers for debugging 
-_OK_C_HEADING=$'\033[1;30;45m';_OK_C_NUMBER=$'\033[1;33;44m';_OK_C_COMMENT=$'\033[1;34;46m';_OK_C_COMMAND=$'\033[1;37;44m' #Custom color scheme                         
-# Tests arguments passing (you can pass arguments after <number>, both at the bash-prompt and the ok-prompt)
-echo "Passed arguments: 1:[$1], 2:[$2], 3:[$3], 4+:[${@:4}] (nr args: $#)"   # Comments starts too early, clearly a bug
-echo "All passed arguments: [$@]"
+# Manipulate customizations (colors)                                                                                                                                         
+unset _OK_C_HEADING;unset _OK_C_NUMBER;unset _OK_C_COMMENT;unset _OK_C_COMMAND;unset _OK_C_PROMPT                           #Reset colors to defaults                    
+_OK_C_HEADING="[h]";_OK_C_NUMBER="[n]";_OK_C_COMMENT="[--]";_OK_C_COMMAND="[C]";_OK_C_PROMPT="[p]"                          #Change colors to text markers for debugging 
+_OK_C_HEADING=$'\033[1;30;45m';_OK_C_NUMBER=$'\033[1;33;44m ';_OK_C_COMMENT=$'\033[1;34;46m';_OK_C_COMMAND=$'\033[1;37;44m' #Custom color scheme                         
+# Tests arguments passing (you can pass arguments after <number>, both at the bash-prompt and the ok-prompt)                              
+echo "Passed arguments: 1:[$1], 2:[$2], 3:[$3], 4+:[${@:4}] (nr args: $#)" # Comment-color starts too early; clearly a bug (so better 
+echo "All passed arguments: [$@]"                                          # not to use a number sign in a command for now)...        
+# Other customizations                                                                                                             
+unset _OK_PROMPT; unset _OK_VERBOSE  # Reset to defaults                                                                       
+_OK_PROMPT="-=> "; _OK_VERBOSE=2     # Show a "nice" prompt, and give all the feedback ok can provide for                      
+_OK_PROMPT="% "; _OK_VERBOSE=0       # Show ancient prompt, and only say the most necessary (don't even show executed command) 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ## "ok" gives you .ok folder profiles for bash
 
 
-💡 Tip: "." (i.e. source) the "ok" script from your profile (.bashrc), e.g:
+💡 Tip: "." (i.e. source) the "ok.sh" script from your profile (.bashrc), e.g:
 
- . ~/ok
+ . ~/ok.sh
 
 See <http://secretgeek.net/ok> for description of how to use "ok"
 

--- a/ok
+++ b/ok
@@ -12,13 +12,12 @@ command (use one):
   <number>        Run the <number>th command from the ".ok" file
   l, list         Show the list from the ".ok" file
   L, list-once    Same as list, but only show when pwd is different from previous run
-  p, list-prompt  Default command. Show the list and wait for prompt (--list and <number> in one command)
+  p, list-prompt  Default command. Show the list and wait for input at the ok-prompt (--list and <number> in one command)
   h, help         Show this usage page
 ok-options:
   -v, --verbose   Show more output, most of the time to stderr
-  -:, --pass-args Next options will be passed as <script-options> (see script-arguments)
 script-arguments:
-  ...             These are passed through, when a line is executed (you can enter these too at the prompt, when used)
+  ...             These are passed through, when a line is executed (you can enter these too at the ok-prompt)
 '
         if [[ -n $1 ]]; then
             echo "$1"
@@ -62,7 +61,6 @@ script-arguments:
 
     # handle command line arguments first
     local re_is_num='^[0-9]+$'
-    local re_num_begin='^[0-9]+ '
     local cmd=list
     local line_nr=0
     local once_check=0
@@ -78,14 +76,13 @@ script-arguments:
         else
             case $1 in
                 #commands
-                l | list)          cmd=list;;
-                L | list-once)     cmd=list; once_check=1;;
-                p | list-prompt)   cmd=list; show_prompt=1;;
+                l | list)          cmd=list; show_prompt=0; once_check=0;;
+                L | list-once)     cmd=list; show_prompt=0; once_check=1;;
+                p | list-prompt)   cmd=list; show_prompt=1; once_check=0;;
                 h | help)          cmd=usage;;
                 #options
                 -\? | -h | --help) cmd=usage;;
                 -v | --verbose)    verbose=1;;
-                -: | --pass-args)  loop_args=0;;
                 *)                 cmd=usage; usage_error="Unknown command/option '$1'";;
             esac
         fi
@@ -112,14 +109,11 @@ script-arguments:
                 _ok_cmd_list
                 if [[ $show_prompt == 1 ]]; then
                     local prompt_input
+                    local re_num_begin='^[0-9]+($| )'
                     read -p "${_OK_C_PROMPT}${PROMPT}${C_NC}" prompt_input
-                    if [[ $prompt_input =~ $re_is_num ]]; then
-                        _ok_cmd_run $prompt_input "$@"
-                    elif [[ $prompt_input =~ $re_num_begin ]]; then
-                        #some bash multi-platform string handling voodoo
-                        line_nr=$(echo "${prompt_input}" | egrep -o '[[:digit:]]+')
-                        args=${prompt_input:${#line_nr}}
-                        _ok_cmd_run $line_nr $args
+                    if [[ $prompt_input =~ $re_num_begin ]]; then
+                        # You can enter arguments at the ok-prompt too
+                        eval _ok_cmd_run $prompt_input
                     else
                         if [[ $verbose == 1 ]]; then
                             >&2 echo "ERROR: entered line number '$line_nr' is not a number"

--- a/ok
+++ b/ok
@@ -4,7 +4,8 @@
 
 ok() {
     function cmd_usage {
-        echo 'Usage: ok command [options]
+        echo 'Usage: ok [ok-options] <number> [script-options..]
+                     ok command [options]
 
 command (use one):
   <number>        Run the <number>th command from the ".ok" file
@@ -12,8 +13,11 @@ command (use one):
   L, list-once    Same as list, but only show when pwd is different from previous run
   p, list-prompt  Default command. Show the list and wait for prompt (--list and <number> in one command)
   h, help         Show this usage page
-options:
+ok-options:
   -v, --verbose   Show more output, most of the time to stderr
+  -, --           Next options will be passed as <script-options> (see next)
+script-options:
+  ...             These are passed through, when a line is executed
 '
         if [[ -n $1 ]]; then
         	echo "$1"
@@ -65,8 +69,7 @@ options:
         if [[ $1 =~ $re_is_num ]]; then
             cmd='run'
             line_nr=$1
-            shift
-            break
+            shift; break
         else
             case $1 in
                 #commands
@@ -77,6 +80,7 @@ options:
                 #options
                 -\? | -h | --help) cmd=usage;;
                 -v | --verbose)    verbose=1;;
+                - | --)            shift; break;;
                 *)                 cmd=usage; usage_error="Unknown command/option '$1'";;
             esac
         fi
@@ -104,7 +108,7 @@ options:
                 if [[ $show_prompt == 1 ]]; then
                     read -p "${_OK_C_PROMPT}${PROMPT}${C_NC}" line_nr
                     if [[ $line_nr =~ $re_is_num ]]; then
-                        cmd_run $line_nr
+                        cmd_run $line_nr "$@"
                     else
                         if [[ $verbose == 1 ]]; then
                             >&2 echo "ERROR: entered line number '$LINE_NR' is not a number"

--- a/ok
+++ b/ok
@@ -4,16 +4,16 @@
 
 ok() {
     function cmd_usage {
-        echo 'Usage: ok command
+        echo 'Usage: ok command [options]
 
 command (use one):
-  <number>           Run the <number>th command from the ".ok" file
-  -l, --list         Show the list from the ".ok" file
-  -L, --list-once    Same as list, but only show when pwd is different from previous run
-  -p, --list-prompt  Default command. Show the list and wait for prompt (--list and <number> in one command)
-  -?, -h, --help     Show this usage page
+  <number>        Run the <number>th command from the ".ok" file
+  l, list         Show the list from the ".ok" file
+  L, list-once    Same as list, but only show when pwd is different from previous run
+  p, list-prompt  Default command. Show the list and wait for prompt (--list and <number> in one command)
+  h, help         Show this usage page
 options:
-  -v, --verbose      Show more output, most of the time to stderr
+  -v, --verbose   Show more output, most of the time to stderr
 '
         if [[ -n $1 ]]; then
         	echo "$1"
@@ -68,12 +68,15 @@ options:
             break
         else
             case $1 in
-                -l | --list)        cmd=list;;
-                -L | --list-once)   cmd=list; once_check=1;;
-                -p | --list-prompt) cmd=list; show_prompt=1;;
-                -\? | -h | --help)  cmd=usage;;
-                -v | --verbose)     verbose=1;;
-                *)                  cmd=usage; usage_error="Unknown command/option '$1'";;
+                #commands
+                l | list)          cmd=list;;
+                L | list-once)     cmd=list; once_check=1;;
+                p | list-prompt)   cmd=list; show_prompt=1;;
+                h | help)          cmd=usage;;
+                #options
+                -\? | -h | --help) cmd=usage;;
+                -v | --verbose)    verbose=1;;
+                *)                 cmd=usage; usage_error="Unknown command/option '$1'";;
             esac
         fi
         shift
@@ -107,7 +110,8 @@ options:
                         fi
                     fi
                 fi
-            elif [[ $once_check == 1 && $_OK_LAST_PWD == $(pwd) ]]; then
+            fi
+            if [[ $verbose = 1 && $once_check == 1 && $_OK_LAST_PWD == $(pwd) ]]; then
                 echo "The listing for this folder has already been shown"
             fi
         elif [[ $cmd == usage ]]; then

--- a/ok
+++ b/ok
@@ -23,10 +23,12 @@ command (use one):
         local LINE_NR=$1
         # save and remove argument. Remaining arguments are passwed to eval automatically
         local LINE_TEXT=$( cat .ok | grep -vE "^#" | sed ${LINE_NR}'!d' )
-        # output the command first
-        echo -e "${C_PROMPT}${PROMPT}${C_COMMAND}${LINE_TEXT}${C_NC}" | sed -E "s/(#.*)\$/${C_COMMENT}\1/1"
-        # remove commented lines, and execute that line from the file
-        eval $LINE_TEXT
+        if [[ -n $LINE_TEXT ]]; then
+            # output the command first
+            echo -e "${C_PROMPT}${PROMPT}${C_COMMAND}${LINE_TEXT}${C_NC}" | sed -E "s/(#.*)\$/${C_COMMENT}\1/1"
+            # remove commented lines, and execute that line from the file
+            eval $LINE_TEXT
+        fi
     }
 
     function cmd_list {

--- a/ok
+++ b/ok
@@ -23,6 +23,7 @@ options:
 
     function cmd_run {
         local LINE_NR=$1
+        shift
         # save and remove argument. Remaining arguments are passwed to eval automatically
         local LINE_TEXT=$( cat .ok | grep -vE "^#" | sed ${LINE_NR}'!d' )
         if [[ -n $LINE_TEXT ]]; then
@@ -96,7 +97,7 @@ options:
     if [ -f .ok ]; then
         # if the user provided a parameter, $1, which contains a number...
         if [[ $cmd == run ]]; then
-            cmd_run $line_nr
+            cmd_run $line_nr "$@"
         elif [[ $cmd == list ]]; then
             if [[ $once_check == 0 || ($once_check == 1 && $_OK_LAST_PWD != $(pwd)) ]]; then
                 cmd_list

--- a/ok
+++ b/ok
@@ -5,8 +5,8 @@
 ok() {
     function _ok_cmd_usage {
         unset -f _ok_cmd_usage #emulate a "local" function
-        echo 'Usage: ok [ok-options] <number> [script-options..]
-                     ok command [options]
+        echo 'Usage: ok [ok-options] <number> [script-arguments..]
+       ok command [ok-options]
 
 command (use one):
   <number>        Run the <number>th command from the ".ok" file
@@ -16,9 +16,9 @@ command (use one):
   h, help         Show this usage page
 ok-options:
   -v, --verbose   Show more output, most of the time to stderr
-  -:, --pass-args Next options will be passed as <script-options> (see next)
-script-options:
-  ...             These are passed through, when a line is executed
+  -:, --pass-args Next options will be passed as <script-options> (see script-arguments)
+script-arguments:
+  ...             These are passed through, when a line is executed (you can enter these too at the prompt, when used)
 '
         if [[ -n $1 ]]; then
             echo "$1"
@@ -62,7 +62,8 @@ script-options:
 
     # handle command line arguments first
     local re_is_num='^[0-9]+$'
-    local cmd='list'
+    local re_num_begin='^[0-9]+ '
+    local cmd=list
     local line_nr=0
     local once_check=0
     local show_prompt=1
@@ -110,12 +111,18 @@ script-options:
             if [[ $once_check == 0 || ($once_check == 1 && $_OK_LAST_PWD != $(pwd)) ]]; then
                 _ok_cmd_list
                 if [[ $show_prompt == 1 ]]; then
-                    read -p "${_OK_C_PROMPT}${PROMPT}${C_NC}" line_nr
-                    if [[ $line_nr =~ $re_is_num ]]; then
-                        _ok_cmd_run $line_nr "$@"
+                    local prompt_input
+                    read -p "${_OK_C_PROMPT}${PROMPT}${C_NC}" prompt_input
+                    if [[ $prompt_input =~ $re_is_num ]]; then
+                        _ok_cmd_run $prompt_input "$@"
+                    elif [[ $prompt_input =~ $re_num_begin ]]; then
+                        #some bash multi-platform string handling voodoo
+                        line_nr=$(echo "${prompt_input}" | egrep -o '[[:digit:]]+')
+                        args=${prompt_input:${#line_nr}}
+                        _ok_cmd_run $line_nr $args
                     else
                         if [[ $verbose == 1 ]]; then
-                            >&2 echo "ERROR: entered line number '$LINE_NR' is not a number"
+                            >&2 echo "ERROR: entered line number '$line_nr' is not a number"
                         fi
                     fi
                 fi

--- a/ok
+++ b/ok
@@ -10,10 +10,12 @@ command (use one):
   <number>           Run the <number>th command from the ".ok" file
   -l, --list         Show the list from the ".ok" file
   -L, --list-once    Same as list, but only show when pwd is different from previous run
-  -?, -h, --help     Show this usage page'
+  -p, --list-prompt  Default command. Show the list and wait for prompt (--list and <number> in one command)
+  -?, -h, --help     Show this usage page
+'
         if [[ -n $1 ]]; then
-            echo
         	echo "$1"
+            echo
         fi
     }
 
@@ -22,7 +24,7 @@ command (use one):
         # save and remove argument. Remaining arguments are passwed to eval automatically
         local LINE_TEXT=$( cat .ok | grep -vE "^#" | sed ${LINE_NR}'!d' )
         # output the command first
-        echo -e "${C_PROMPT}\$ ${C_COMMAND}${LINE_TEXT}${C_NC}" | sed -E "s/(#.*)\$/${C_COMMENT}\1/1"
+        echo -e "${C_PROMPT}${PROMPT}${C_COMMAND}${LINE_TEXT}${C_NC}" | sed -E "s/(#.*)\$/${C_COMMENT}\1/1"
         # remove commented lines, and execute that line from the file
         eval $LINE_TEXT
     }
@@ -47,6 +49,7 @@ command (use one):
     local cmd='list'
     local line_nr=0
     local once_check=0
+    local show_prompt=1
     local usage_error=
     while (( $# > 0 )) ; do
         if [[ $1 =~ $re_is_num ]]; then
@@ -58,6 +61,7 @@ command (use one):
             case $1 in
                 -l | --list)        cmd=list;;
                 -L | --list-once)   cmd=list; once_check=1;;
+                -p | --list-prompt) cmd=list; show_prompt=1;;
                 -? | -h | --help )  cmd=usage;;
                 *)                  cmd=usage; usage_error="Unknown command/option '$1'";;
             esac
@@ -72,6 +76,8 @@ command (use one):
     if [ -z ${_OK_C_COMMENT+x} ]; then local C_COMMENT=$(tput setaf 4); else local C_COMMENT=$_OK_C_COMMENT; fi #COMMENT defaults to BLUE
     if [ -z ${_OK_C_COMMAND+x} ]; then local C_COMMAND=$C_NC;           else local C_COMMAND=$_OK_C_COMMAND; fi #COMMAND defaults to NO COLOR
     if [ -z ${_OK_C_PROMPT+x} ];  then local C_PROMPT=$C_NUMBER;        else local C_PROMPT=$_OK_C_PROMPT;   fi #PROMPT defaults to same color as NUMBER
+    # other customizations
+    if [ -z ${_OK_PROMPT+x} ];    then local PROMPT="$ ";               else local PROMPT=$_OK_PROMPT;       fi
 
     # if there is a file called .ok...
     if [ -f .ok ]; then
@@ -81,6 +87,12 @@ command (use one):
         elif [[ $cmd == list ]]; then
             if [[ $once_check == 0 || ($once_check == 1 && $_OK_LAST_PWD != $(pwd)) ]]; then
                 cmd_list
+                if [[ $show_prompt == 1 ]]; then
+                    read -p "${_OK_C_PROMPT}${PROMPT}${C_NC}" line_nr
+                    if [[ $line_nr =~ $re_is_num ]]; then
+                        cmd_run $line_nr
+                    fi
+                fi
             fi
         elif [[ $cmd == usage ]]; then
             cmd_usage "$usage_error"

--- a/ok
+++ b/ok
@@ -21,8 +21,8 @@ script-arguments:
   ...             These are passed through, when a line is executed (you can enter these too at the ok-prompt)
 '
         if [[ -n $1 ]]; then
-            echo "$1"
-            echo
+            echo -e "$1\n"
+            return 1
         fi
     }
 
@@ -43,6 +43,7 @@ script-arguments:
             if [[ $verbose -ge 2 ]]; then
                 >&2 echo "ERROR: entered line number '$LINE_NR' does not exist"
             fi
+            return 1
         fi
     }
 
@@ -107,31 +108,32 @@ script-arguments:
     if [ -f .ok ]; then
         # if the user provided a parameter, $1, which contains a number...
         if [[ $cmd == run ]]; then
-            _ok_cmd_run $line_nr "$@"
+            _ok_cmd_run $line_nr "$@" || return $?
         elif [[ $cmd == list ]]; then
             if [[ $once_check == 0 || ($once_check == 1 && $_OK_LAST_PWD != $(pwd)) ]]; then
-                _ok_cmd_list
+                _ok_cmd_list || return $?
                 if [[ $show_prompt == 1 ]]; then
                     local prompt_input
                     local re_num_begin='^[0-9]+($| )'
                     read -p "${C_PROMPT}${PROMPT}${C_NC}" prompt_input
                     if [[ $prompt_input =~ $re_num_begin ]]; then
                         # You can enter arguments at the ok-prompt too
-                        eval _ok_cmd_run $prompt_input
+                        eval _ok_cmd_run $prompt_input || return $?
                     else
                         if [[ $verbose -ge 2 ]]; then
-                            >&2 echo "ERROR: entered line number '$line_nr' is not a number"
+                            >&2 echo "ERROR: input '$prompt_input' does not start with a number"
                         fi
+                        return 1
                     fi
                 fi
             fi
             if [[ $verbose -ge 2 && $once_check == 1 && $_OK_LAST_PWD == $(pwd) ]]; then
                 echo "The listing for this folder has already been shown"
             fi
+            export _OK_LAST_PWD=$(pwd)
         elif [[ $cmd == usage ]]; then
-            _ok_cmd_usage "$usage_error"
+            _ok_cmd_usage "$usage_error" || return $?
         fi
-        export _OK_LAST_PWD=$(pwd)
     else
         if [[ $verbose -ge 2 ]]; then
             echo "Nothing to do: this folder doesn't have an '.ok' file"

--- a/ok
+++ b/ok
@@ -3,7 +3,8 @@
 # tip: "." (i.e. source) this file from your profile (.bashrc), e.g. ". ~/ok"
 
 ok() {
-    function cmd_usage {
+    function _ok_cmd_usage {
+        unset -f _ok_cmd_usage #emulate a "local" function
         echo 'Usage: ok [ok-options] <number> [script-options..]
                      ok command [options]
 
@@ -15,17 +16,18 @@ command (use one):
   h, help         Show this usage page
 ok-options:
   -v, --verbose   Show more output, most of the time to stderr
-  -, --           Next options will be passed as <script-options> (see next)
+  -:, --pass-args Next options will be passed as <script-options> (see next)
 script-options:
   ...             These are passed through, when a line is executed
 '
         if [[ -n $1 ]]; then
-        	echo "$1"
+            echo "$1"
             echo
         fi
     }
 
-    function cmd_run {
+    function _ok_cmd_run {
+        unset -f _ok_cmd_run
         local LINE_NR=$1
         shift
         # save and remove argument. Remaining arguments are passwed to eval automatically
@@ -42,7 +44,8 @@ script-options:
         fi
     }
 
-    function cmd_list {
+    function _ok_cmd_list {
+        unset -f _ok_cmd_list
         # list the content of the file, with a number (1-based) before each line,
         # except lines starting with a "#", those are printed red without a number) as headers
         cat .ok | awk -v h=$C_HEADING -v n=$C_NUMBER -v c=$C_COMMENT -v m=$C_COMMAND -v x=$C_NC $'
@@ -65,11 +68,12 @@ script-options:
     local show_prompt=1
     local usage_error=
     local verbose=0
-    while (( $# > 0 )) ; do
+    local loop_args=1
+    while (( $# > 0 && $loop_args == 1 )) ; do
         if [[ $1 =~ $re_is_num ]]; then
-            cmd='run'
+            cmd=run
             line_nr=$1
-            shift; break
+            loop_args=0
         else
             case $1 in
                 #commands
@@ -80,7 +84,7 @@ script-options:
                 #options
                 -\? | -h | --help) cmd=usage;;
                 -v | --verbose)    verbose=1;;
-                - | --)            shift; break;;
+                -: | --pass-args)  loop_args=0;;
                 *)                 cmd=usage; usage_error="Unknown command/option '$1'";;
             esac
         fi
@@ -101,14 +105,14 @@ script-options:
     if [ -f .ok ]; then
         # if the user provided a parameter, $1, which contains a number...
         if [[ $cmd == run ]]; then
-            cmd_run $line_nr "$@"
+            _ok_cmd_run $line_nr "$@"
         elif [[ $cmd == list ]]; then
             if [[ $once_check == 0 || ($once_check == 1 && $_OK_LAST_PWD != $(pwd)) ]]; then
-                cmd_list
+                _ok_cmd_list
                 if [[ $show_prompt == 1 ]]; then
                     read -p "${_OK_C_PROMPT}${PROMPT}${C_NC}" line_nr
                     if [[ $line_nr =~ $re_is_num ]]; then
-                        cmd_run $line_nr "$@"
+                        _ok_cmd_run $line_nr "$@"
                     else
                         if [[ $verbose == 1 ]]; then
                             >&2 echo "ERROR: entered line number '$LINE_NR' is not a number"
@@ -120,7 +124,7 @@ script-options:
                 echo "The listing for this folder has already been shown"
             fi
         elif [[ $cmd == usage ]]; then
-            cmd_usage "$usage_error"
+            _ok_cmd_usage "$usage_error"
         fi
         export _OK_LAST_PWD=$(pwd)
     else

--- a/ok
+++ b/ok
@@ -5,8 +5,8 @@
 ok() {
     function _ok_cmd_usage {
         unset -f _ok_cmd_usage #emulate a "local" function
-        echo 'Usage: ok [ok-options] <number> [script-arguments..]
-       ok command [ok-options]
+        echo 'Usage: ok [options] <number> [script-arguments..]
+       ok command [options]
 
 command (use one):
   <number>        Run the <number>th command from the ".ok" file
@@ -14,8 +14,9 @@ command (use one):
   L, list-once    Same as list, but only show when pwd is different from previous run
   p, list-prompt  Default command. Show the list and wait for input at the ok-prompt (--list and <number> in one command)
   h, help         Show this usage page
-ok-options:
+options:
   -v, --verbose   Show more output, most of the time to stderr
+  -q, --quiet     Only show really necessary output
 script-arguments:
   ...             These are passed through, when a line is executed (you can enter these too at the ok-prompt)
 '
@@ -32,12 +33,14 @@ script-arguments:
         # save and remove argument. Remaining arguments are passwed to eval automatically
         local LINE_TEXT=$( cat .ok | grep -vE "^#" | sed ${LINE_NR}'!d' )
         if [[ -n $LINE_TEXT ]]; then
-            # output the command first
-            echo -e "${C_PROMPT}${PROMPT}${C_COMMAND}${LINE_TEXT}${C_NC}" | sed -E "s/(#.*)\$/${C_COMMENT}\1/1"
+            if [[ $verbose -ge 1 ]]; then
+                # output the command first
+                echo -e "${C_PROMPT}${PROMPT}${C_COMMAND}${LINE_TEXT}${C_NC}" | sed -E "s/(#.*)\$/${C_COMMENT}\1/1"
+            fi
             # remove commented lines, and execute that line from the file
             eval $LINE_TEXT
         else
-            if [[ $verbose == 1 ]]; then
+            if [[ $verbose -ge 2 ]]; then
                 >&2 echo "ERROR: entered line number '$LINE_NR' does not exist"
             fi
         fi
@@ -47,7 +50,7 @@ script-arguments:
         unset -f _ok_cmd_list
         # list the content of the file, with a number (1-based) before each line,
         # except lines starting with a "#", those are printed red without a number) as headers
-        cat .ok | awk -v h=$C_HEADING -v n=$C_NUMBER -v c=$C_COMMENT -v m=$C_COMMAND -v x=$C_NC $'
+        cat .ok | awk -v h="$C_HEADING" -v n="$C_NUMBER" -v c="$C_COMMENT" -v m="$C_COMMAND" -v x="$C_NC" $'
             $0 ~ /^#/ {
                 #print the (sub-)headings
                 print x h $0 x;
@@ -59,6 +62,17 @@ script-arguments:
             }'
     }
 
+    # used for colored output (see: https://stackoverflow.com/a/20983251/56)
+    local C_NC=$(tput sgr 0)
+    if [ -z ${_OK_C_HEADING+x} ]; then local C_HEADING=$(tput setaf 1); else local C_HEADING=$_OK_C_HEADING; fi #HEADING defaults to RED
+    if [ -z ${_OK_C_NUMBER+x} ];  then local C_NUMBER=$(tput setaf 6);  else local C_NUMBER=$_OK_C_NUMBER;   fi #NUMBER defaults to CYAN
+    if [ -z ${_OK_C_COMMENT+x} ]; then local C_COMMENT=$(tput setaf 4); else local C_COMMENT=$_OK_C_COMMENT; fi #COMMENT defaults to BLUE
+    if [ -z ${_OK_C_COMMAND+x} ]; then local C_COMMAND=$C_NC;           else local C_COMMAND=$_OK_C_COMMAND; fi #COMMAND defaults to NO COLOR
+    if [ -z ${_OK_C_PROMPT+x} ];  then local C_PROMPT=$C_NUMBER;        else local C_PROMPT=$_OK_C_PROMPT;   fi #PROMPT defaults to same color as NUMBER
+    # other customizations (some environment variables can be overridden by arguments)
+    if [ -z ${_OK_PROMPT+x} ];    then local PROMPT="$ ";               else local PROMPT=$_OK_PROMPT;       fi
+    if [ -z ${_OK_VERBOSE+x} ];   then local verbose=1;                 else local verbose=$_OK_VERBOSE;     fi
+
     # handle command line arguments first
     local re_is_num='^[0-9]+$'
     local cmd=list
@@ -66,8 +80,7 @@ script-arguments:
     local once_check=0
     local show_prompt=1
     local usage_error=
-    local verbose=0
-    local loop_args=1
+    local loop_args=1 #the pascal-way to break loops
     while (( $# > 0 && $loop_args == 1 )) ; do
         if [[ $1 =~ $re_is_num ]]; then
             cmd=run
@@ -82,22 +95,13 @@ script-arguments:
                 h | help)          cmd=usage;;
                 #options
                 -\? | -h | --help) cmd=usage;;
-                -v | --verbose)    verbose=1;;
+                -v | --verbose)    verbose=2;;
+                -q | --quiet)      verbose=0;;
                 *)                 cmd=usage; usage_error="Unknown command/option '$1'";;
             esac
         fi
         shift
     done
-
-    # used for colored output (see: https://stackoverflow.com/a/20983251/56)
-    local C_NC=$(tput sgr 0)
-    if [ -z ${_OK_C_HEADING+x} ]; then local C_HEADING=$(tput setaf 1); else local C_HEADING=$_OK_C_HEADING; fi #HEADING defaults to RED
-    if [ -z ${_OK_C_NUMBER+x} ];  then local C_NUMBER=$(tput setaf 6);  else local C_NUMBER=$_OK_C_NUMBER;   fi #NUMBER defaults to CYAN
-    if [ -z ${_OK_C_COMMENT+x} ]; then local C_COMMENT=$(tput setaf 4); else local C_COMMENT=$_OK_C_COMMENT; fi #COMMENT defaults to BLUE
-    if [ -z ${_OK_C_COMMAND+x} ]; then local C_COMMAND=$C_NC;           else local C_COMMAND=$_OK_C_COMMAND; fi #COMMAND defaults to NO COLOR
-    if [ -z ${_OK_C_PROMPT+x} ];  then local C_PROMPT=$C_NUMBER;        else local C_PROMPT=$_OK_C_PROMPT;   fi #PROMPT defaults to same color as NUMBER
-    # other customizations
-    if [ -z ${_OK_PROMPT+x} ];    then local PROMPT="$ ";               else local PROMPT=$_OK_PROMPT;       fi
 
     # if there is a file called .ok...
     if [ -f .ok ]; then
@@ -110,18 +114,18 @@ script-arguments:
                 if [[ $show_prompt == 1 ]]; then
                     local prompt_input
                     local re_num_begin='^[0-9]+($| )'
-                    read -p "${_OK_C_PROMPT}${PROMPT}${C_NC}" prompt_input
+                    read -p "${C_PROMPT}${PROMPT}${C_NC}" prompt_input
                     if [[ $prompt_input =~ $re_num_begin ]]; then
                         # You can enter arguments at the ok-prompt too
                         eval _ok_cmd_run $prompt_input
                     else
-                        if [[ $verbose == 1 ]]; then
+                        if [[ $verbose -ge 2 ]]; then
                             >&2 echo "ERROR: entered line number '$line_nr' is not a number"
                         fi
                     fi
                 fi
             fi
-            if [[ $verbose = 1 && $once_check == 1 && $_OK_LAST_PWD == $(pwd) ]]; then
+            if [[ $verbose -ge 2 && $once_check == 1 && $_OK_LAST_PWD == $(pwd) ]]; then
                 echo "The listing for this folder has already been shown"
             fi
         elif [[ $cmd == usage ]]; then
@@ -129,7 +133,7 @@ script-arguments:
         fi
         export _OK_LAST_PWD=$(pwd)
     else
-        if [[ $verbose == 1 ]]; then
+        if [[ $verbose -ge 2 ]]; then
             echo "Nothing to do: this folder doesn't have an '.ok' file"
         fi
     fi

--- a/ok
+++ b/ok
@@ -5,21 +5,34 @@
 ok() {
     function _ok_cmd_usage {
         unset -f _ok_cmd_usage #emulate a "local" function
-        echo 'Usage: ok [options] <number> [script-arguments..]
+        echo -e "Usage: ok [options] <number> [script-arguments..]
        ok command [options]
 
 command (use one):
-  <number>        Run the <number>th command from the ".ok" file
-  l, list         Show the list from the ".ok" file
-  L, list-once    Same as list, but only show when pwd is different from previous run
-  p, list-prompt  Default command. Show the list and wait for input at the ok-prompt (--list and <number> in one command)
-  h, help         Show this usage page
+  <number>        Run the <number>th command from the '.ok' file.
+  l, list         Show the list from the '.ok' file.
+  L, list-once    Same as list, but only show when pwd is different from when the list was last shown.
+  p, list-prompt  Show the list and wait for input at the ok-prompt (like --list and <number> in one command). Default command.
+  h, help         Show this usage page.
 options:
-  -v, --verbose   Show more output, most of the time to stderr
-  -q, --quiet     Only show really necessary output
+  -v, --verbose   Show more output, most of the time to stderr.
+  -q, --quiet     Only show really necessary output.
 script-arguments:
-  ...             These are passed through, when a line is executed (you can enter these too at the ok-prompt)
-'
+  ...             These are passed through, when a line is executed (you can enter these too at the ok-prompt)\n"
+
+        if [[ $verbose -ge 2 ]]; then
+            if [ -z ${_OK_PROMPT+x} ];    then local p="unset";  else local p="'$_OK_PROMPT'";  fi
+            if [ -z ${_OK_VERBOSE+x} ];   then local v="unset";  else local v="'$_OK_VERBOSE'"; fi
+            echo -e "environment variables (used for colored output; current colors are shown):
+  _OK_C_HEADING   ${_OK_C_HEADING}Color-code${C_NC} for lines starting with a comment (heading). Defaults to red.
+  _OK_C_NUMBER    ${_OK_C_NUMBER}Color-code${C_NC} for numbering. Defaults to cyan.
+  _OK_C_COMMENT   ${_OK_C_COMMENT}Color-code${C_NC} for comments after commands. Defaults to blue.
+  _OK_C_COMMAND   ${_OK_C_COMMAND}Color-code${C_NC} for commands. Defaults to color-reset.
+  _OK_C_PROMPT    ${_OK_C_PROMPT}Color-code${C_NC} for prompt (both input as command confirmation). Defaults to color for numbering.
+environment variables (other):
+  _OK_PROMPT      String ($p) used as prompt (both input as command confirmation). Defaults to '$ '.
+  _OK_VERBOSE     Level ($v) of feedback ok provides. 0=quiet, 1=normal, 2=verbose. Defaults to 1. Can be overriden with --verbose or --quiet.\n"
+        fi
         if [[ -n $1 ]]; then
             echo -e "$1\n"
             return 1

--- a/ok
+++ b/ok
@@ -12,6 +12,8 @@ command (use one):
   -L, --list-once    Same as list, but only show when pwd is different from previous run
   -p, --list-prompt  Default command. Show the list and wait for prompt (--list and <number> in one command)
   -?, -h, --help     Show this usage page
+options:
+  -v, --verbose      Show more output, most of the time to stderr
 '
         if [[ -n $1 ]]; then
         	echo "$1"
@@ -28,6 +30,10 @@ command (use one):
             echo -e "${C_PROMPT}${PROMPT}${C_COMMAND}${LINE_TEXT}${C_NC}" | sed -E "s/(#.*)\$/${C_COMMENT}\1/1"
             # remove commented lines, and execute that line from the file
             eval $LINE_TEXT
+        else
+            if [[ $verbose == 1 ]]; then
+                >&2 echo "ERROR: entered line number '$LINE_NR' does not exist"
+            fi
         fi
     }
 
@@ -53,6 +59,7 @@ command (use one):
     local once_check=0
     local show_prompt=1
     local usage_error=
+    local verbose=0
     while (( $# > 0 )) ; do
         if [[ $1 =~ $re_is_num ]]; then
             cmd='run'
@@ -64,7 +71,8 @@ command (use one):
                 -l | --list)        cmd=list;;
                 -L | --list-once)   cmd=list; once_check=1;;
                 -p | --list-prompt) cmd=list; show_prompt=1;;
-                -? | -h | --help )  cmd=usage;;
+                -\? | -h | --help)  cmd=usage;;
+                -v | --verbose)     verbose=1;;
                 *)                  cmd=usage; usage_error="Unknown command/option '$1'";;
             esac
         fi
@@ -93,12 +101,22 @@ command (use one):
                     read -p "${_OK_C_PROMPT}${PROMPT}${C_NC}" line_nr
                     if [[ $line_nr =~ $re_is_num ]]; then
                         cmd_run $line_nr
+                    else
+                        if [[ $verbose == 1 ]]; then
+                            >&2 echo "ERROR: entered line number '$LINE_NR' is not a number"
+                        fi
                     fi
                 fi
+            elif [[ $once_check == 1 && $_OK_LAST_PWD == $(pwd) ]]; then
+                echo "The listing for this folder has already been shown"
             fi
         elif [[ $cmd == usage ]]; then
             cmd_usage "$usage_error"
         fi
         export _OK_LAST_PWD=$(pwd)
+    else
+        if [[ $verbose == 1 ]]; then
+            echo "Nothing to do: this folder doesn't have an '.ok' file"
+        fi
     fi
 }

--- a/ok
+++ b/ok
@@ -3,6 +3,68 @@
 # tip: "." (i.e. source) this file from your profile (.bashrc), e.g. ". ~/ok"
 
 ok() {
+    function cmd_usage {
+        echo 'Usage: ok command
+
+command (use one):
+  <number>           Run the <number>th command from the ".ok" file
+  -l, --list         Show the list from the ".ok" file
+  -L, --list-once    Same as list, but only show when pwd is different from previous run
+  -?, -h, --help     Show this usage page'
+        if [[ -n $1 ]]; then
+            echo
+        	echo "$1"
+        fi
+    }
+
+    function cmd_run {
+        local LINE_NR=$1
+        # save and remove argument. Remaining arguments are passwed to eval automatically
+        local LINE_TEXT=$( cat .ok | grep -vE "^#" | sed ${LINE_NR}'!d' )
+        # output the command first
+        echo -e "${C_PROMPT}\$ ${C_COMMAND}${LINE_TEXT}${C_NC}" | sed -E "s/(#.*)\$/${C_COMMENT}\1/1"
+        # remove commented lines, and execute that line from the file
+        eval $LINE_TEXT
+    }
+
+    function cmd_list {
+        # list the content of the file, with a number (1-based) before each line,
+        # except lines starting with a "#", those are printed red without a number) as headers
+        cat .ok | awk -v h=$C_HEADING -v n=$C_NUMBER -v c=$C_COMMENT -v m=$C_COMMAND -v x=$C_NC $'
+            $0 ~ /^#/ {
+                #print the (sub-)headings
+                print x h $0 x;
+            }
+            $0 ~ /^[^#]/ {
+                #print the commands
+                sub(/#/,c "#");
+                print x n "" ++i "." m " " $0 x;
+            }'
+    }
+
+    # handle command line arguments first
+    local re_is_num='^[0-9]+$'
+    local cmd='list'
+    local line_nr=0
+    local once_check=0
+    local usage_error=
+    while (( $# > 0 )) ; do
+        if [[ $1 =~ $re_is_num ]]; then
+            cmd='run'
+            line_nr=$1
+            shift
+            break
+        else
+            case $1 in
+                -l | --list)        cmd=list;;
+                -L | --list-once)   cmd=list; once_check=1;;
+                -? | -h | --help )  cmd=usage;;
+                *)                  cmd=usage; usage_error="Unknown command/option '$1'";;
+            esac
+        fi
+        shift
+    done
+
     # used for colored output (see: https://stackoverflow.com/a/20983251/56)
     local C_NC=$(tput sgr 0)
     if [ -z ${_OK_C_HEADING+x} ]; then local C_HEADING=$(tput setaf 1); else local C_HEADING=$_OK_C_HEADING; fi #HEADING defaults to RED
@@ -13,30 +75,16 @@ ok() {
 
     # if there is a file called .ok...
     if [ -f .ok ]; then
-        re='^[0-9]+$'
         # if the user provided a parameter, $1, which contains a number...
-        if [[ $1 =~ $re ]] ; then
-            # save and remove argument. Remaining arguments are passwed to eval automatically
-            LINE_NR=$1
-            shift
-            LINE_TEXT=$( cat .ok | grep -vE "^#" | sed ${LINE_NR}'!d' )
-            # output the command first
-            echo -e "${C_PROMPT}\$ ${C_COMMAND}${LINE_TEXT}${C_NC}" | sed -E "s/(#.*)\$/${C_COMMENT}\1/1"
-            # remove commented lines, and execute that line from the file
-            eval $LINE_TEXT
-        else
-            # list the content of the file, with a number (1-based) before each line,
-            # except lines starting with a "#", those are printed red without a number) as headers
-            cat .ok | awk -v h=$C_HEADING -v n=$C_NUMBER -v c=$C_COMMENT -v m=$C_COMMAND -v x=$C_NC $'
-                $0 ~ /^#/ {
-                    #print the (sub-)headings
-                    print x h $0 x;
-                }
-                $0 ~ /^[^#]/ {
-                    #print the commands
-                    sub(/#/,c "#");
-                    print x n "" ++i "." m " " $0 x;
-                }'
+        if [[ $cmd == run ]]; then
+            cmd_run $line_nr
+        elif [[ $cmd == list ]]; then
+            if [[ $once_check == 0 || ($once_check == 1 && $_OK_LAST_PWD != $(pwd)) ]]; then
+                cmd_list
+            fi
+        elif [[ $cmd == usage ]]; then
+            cmd_usage "$usage_error"
         fi
+        export _OK_LAST_PWD=$(pwd)
     fi
 }

--- a/ok.sh
+++ b/ok.sh
@@ -45,7 +45,7 @@ environment variables (other):
         local LINE_NR=$1 #LINE_NR is guaranteed to be 1 or more
         shift
         # get the line to be executed
-        local LINE_TEXT=$( cat .ok | grep -vE "^#" | sed ${LINE_NR}'!d' )
+        local LINE_TEXT=$( cat .ok | grep -vE "^(#|$)" | sed ${LINE_NR}'!d' )
         if [[ -n $LINE_TEXT ]]; then
             if [[ $verbose -ge 1 ]]; then
                 # output the command first
@@ -66,8 +66,8 @@ environment variables (other):
         # list the content of the file, with a number (1-based) before each line,
         # except lines starting with a "#", those are printed red without a number) as headers
         cat .ok | awk -v h="$C_HEADING" -v n="$C_NUMBER" -v c="$C_COMMENT" -v m="$C_COMMAND" -v x="$C_NC" $'
-            $0 ~ /^#/ {
-                #print the (sub-)headings
+            $0 ~ /^(#|$)/ {
+                #print the (sub-)headings and/or empty lines
                 print x h $0 x;
             }
             $0 ~ /^[^#]/ {


### PR DESCRIPTION
Big change in amounts code changed, but mostly to enable working with arguments more effectively. The base is the same:

* There is now a "help" page
* Made "list-once" (same as "list", but doesn't show the list twice if `pwd` didn't change)
* There is now a "list-promp" command
* Added options to make output more or less verbose

I'm really interested what you think of this. I need some feedback first. I'm a bit uncertain about --quiet/--verbose options and the renaming to `ok.sh` (however, I couldn't leave them unimplemented).

So let me know what you think! 