### PR TITLE
Small ideas

### DIFF
--- a/.ok
+++ b/.ok
@@ -1,14 +1,15 @@
-# Manipulate customizations (colors)                                                                                                                                         
+# Manipulate customizations (colors)                                                                                                                                          
 unset _OK_C_HEADING;unset _OK_C_NUMBER;unset _OK_C_COMMENT;unset _OK_C_COMMAND;unset _OK_C_PROMPT                           #Reset colors to defaults                    
 _OK_C_HEADING="[h]";_OK_C_NUMBER="[n]";_OK_C_COMMENT="[--]";_OK_C_COMMAND="[C]";_OK_C_PROMPT="[p]"                          #Change colors to text markers for debugging 
 _OK_C_HEADING=$'\033[1;30;45m';_OK_C_NUMBER=$'\033[1;33;44m ';_OK_C_COMMENT=$'\033[1;34;46m';_OK_C_COMMAND=$'\033[1;37;44m' #Custom color scheme                         
-# Other customizations                                                                                                             
+# Other customizations                                                                                                                                             
 unset _OK_PROMPT; unset _OK_VERBOSE; unset _OK_LIST_PROMPT  # Reset to defaults                                                                               
-_OK_PROMPT="-=> "; _OK_VERBOSE=2; _OK_LIST_PROMPT=1         # Show a "nice" prompt, and give all the feedback ok can provide for, and default list'n'prompt   
-_OK_PROMPT="% "; _OK_VERBOSE=0; _OK_LIST_PROMPT=0           # Show ancient prompt, and only say the most necessary (don't even show executed command)         
+_OK_PROMPT="-=> "; _OK_VERBOSE=2; _OK_PROMPT_DEFAULT=1      # Show a "nice" prompt, and give all the feedback ok can provide for, and default list'n'prompt   
+_OK_PROMPT="% "; _OK_VERBOSE=0; _OK_PROMPT_DEFAULT=0        # Show ancient prompt, and only say the most necessary (don't even show executed command)         
 
-# Tests arguments passing (you can pass arguments after <number>, both at the bash-prompt and the ok-prompt)                              
-echo "Passed arguments: 1:[$1], 2:[$2], 3:[$3], 4+:[${@:4}] (nr args: $#)" # Comment-color starts too early; clearly a bug (so better 
-echo "All passed arguments: [$@]"                                          # not to use a number sign in a command for now)...        
-ok help --verbose                                                          # Show help page of 🆗, including environment variables
-set | grep "^_OK_"                                                         # Show all set environment variables, used with ok-bash
+# Tests arguments passing (you can pass arguments after <number>, both at the bash-prompt and the ok-prompt)                                
+echo "Passed arguments: 1:[$1], 2:[$2], 3:[$3], 4+:[${@:4}] (nr args: $#)" # Comment-color starts too early; clearly a bug (so better  
+echo "All passed arguments: [$@]"                                          # not to use a number sign in a command for now)...         
+
+ok help --verbose                                                          # Show help page of 🆗, including environment variables     
+set | grep "^_OK_"                                                         # Show all set environment variables, used with ok-bash     

--- a/.ok
+++ b/.ok
@@ -3,11 +3,12 @@ unset _OK_C_HEADING;unset _OK_C_NUMBER;unset _OK_C_COMMENT;unset _OK_C_COMMAND;u
 _OK_C_HEADING="[h]";_OK_C_NUMBER="[n]";_OK_C_COMMENT="[--]";_OK_C_COMMAND="[C]";_OK_C_PROMPT="[p]"                          #Change colors to text markers for debugging 
 _OK_C_HEADING=$'\033[1;30;45m';_OK_C_NUMBER=$'\033[1;33;44m ';_OK_C_COMMENT=$'\033[1;34;46m';_OK_C_COMMAND=$'\033[1;37;44m' #Custom color scheme                         
 # Other customizations                                                                                                             
-unset _OK_PROMPT; unset _OK_VERBOSE  # Reset to defaults                                                                       
-_OK_PROMPT="-=> "; _OK_VERBOSE=2     # Show a "nice" prompt, and give all the feedback ok can provide for                      
-_OK_PROMPT="% "; _OK_VERBOSE=0       # Show ancient prompt, and only say the most necessary (don't even show executed command) 
+unset _OK_PROMPT; unset _OK_VERBOSE; unset _OK_LIST_PROMPT  # Reset to defaults                                                                               
+_OK_PROMPT="-=> "; _OK_VERBOSE=2; _OK_LIST_PROMPT=1         # Show a "nice" prompt, and give all the feedback ok can provide for, and default list'n'prompt   
+_OK_PROMPT="% "; _OK_VERBOSE=0; _OK_LIST_PROMPT=0           # Show ancient prompt, and only say the most necessary (don't even show executed command)         
 
 # Tests arguments passing (you can pass arguments after <number>, both at the bash-prompt and the ok-prompt)                              
 echo "Passed arguments: 1:[$1], 2:[$2], 3:[$3], 4+:[${@:4}] (nr args: $#)" # Comment-color starts too early; clearly a bug (so better 
 echo "All passed arguments: [$@]"                                          # not to use a number sign in a command for now)...        
 ok help --verbose                                                          # Show help page of 🆗, including environment variables
+set | grep "^_OK_"                                                         # Show all set environment variables, used with ok-bash

--- a/ok.sh
+++ b/ok.sh
@@ -181,6 +181,13 @@ environment variables (for internal use):
 if [[ $called == $0 ]]; then
     # tip: "." (i.e. source) this file from your profile (.bashrc), e.g. ". ~/path/to/ok-bash/ok.sh"
     echo 'tip: "." (i.e. source) this file from your profile (.bashrc), e.g. ". '${_OK__PATH_TO_ME}'/ok.sh"'
+    echo
+    echo "arguments, if you need to customize (these can also be set via arguments/environment):"
+    echo "  prompt <prompt> Use the supplied prompt (e.g. prompt '> ')"
+    echo "  prompt_default  Prompt default when issueing running ok without arguments"
+    echo "  verbose         Enable verbose mode"
+    echo "  quiet           Enable quiet mode"
+    echo
 else
     # Reset all used environment variables
     unset _OK_C_HEADING; unset _OK_C_NUMBER; unset _OK_C_COMMENT; unset _OK_C_COMMAND; unset _OK_C_PROMPT

--- a/ok.sh
+++ b/ok.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-# tip: "." (i.e. source) this file from your profile (.bashrc), e.g. ". ~/path/to/ok-bash/ok.sh"
+called=$_
+
+#basically, get the absolute path of this script (handy for loads of things)
+pushd "$(dirname "${BASH_SOURCE[@]}")" > /dev/null;
+_OK_PATH_TO_ME=$(pwd)
+popd > /dev/null;
+
 
 ok() {
     function _ok_cmd_usage {
@@ -31,7 +37,8 @@ script-arguments:
   _OK_C_PROMPT    ${_OK_C_PROMPT}Color-code${C_NC} for prompt (both input as command confirmation). Defaults to color for numbering.
 environment variables (other):
   _OK_PROMPT      String ($p) used as prompt (both input as command confirmation). Defaults to '$ '.
-  _OK_VERBOSE     Level ($v) of feedback ok provides. 0=quiet, 1=normal, 2=verbose. Defaults to 1. Can be overriden with --verbose or --quiet.\n"
+  _OK_VERBOSE     Level ($v) of feedback ok provides. 0=quiet, 1=normal, 2=verbose. Defaults to 1. Can be overriden with --verbose or --quiet.
+  _OK_PATH_TO_ME  The path ($_OK_PATH_TO_ME) to the location of this script (for internal use).\n"
         fi
         if [[ -n $1 ]]; then
             echo -e "$1\n"
@@ -153,3 +160,9 @@ environment variables (other):
         fi
     fi
 }
+
+if [[ $called == $0 ]]; then
+    # tip: "." (i.e. source) this file from your profile (.bashrc), e.g. ". ~/path/to/ok-bash/ok.sh"
+    echo 'tip: "." (i.e. source) this file from your profile (.bashrc), e.g. ". '${_OK_PATH_TO_ME}'/ok.sh"'
+fi
+unset called

--- a/ok.sh
+++ b/ok.sh
@@ -181,5 +181,20 @@ environment variables (for internal use):
 if [[ $called == $0 ]]; then
     # tip: "." (i.e. source) this file from your profile (.bashrc), e.g. ". ~/path/to/ok-bash/ok.sh"
     echo 'tip: "." (i.e. source) this file from your profile (.bashrc), e.g. ". '${_OK__PATH_TO_ME}'/ok.sh"'
+else
+    # Reset all used environment variables
+    unset _OK_C_HEADING; unset _OK_C_NUMBER; unset _OK_C_COMMENT; unset _OK_C_COMMAND; unset _OK_C_PROMPT
+    unset _OK_PROMPT; unset _OK_PROMPT_DEFAULT; unset _OK_VERBOSE; unset _OK__LAST_PWD
+    # Process some installation helpers
+    while (( $# > 0 )) ; do
+        case $1 in
+            prompt) if [[ $# -ge 2 ]]; then export _OK_PROMPT=$2; shift; else echo "the prompt argument needs the actual prompt as 2nd argument"; fi;;
+            prompt_default) export _OK_PROMPT_DEFAULT=1;;
+            verbose)        export _OK_VERBOSE=2;;
+            quiet)          export _OK_VERBOSE=0;;
+            *) echo "Ignoring unknown argument '$1'";;
+        esac
+        shift
+    done
 fi
 unset called

--- a/ok.sh
+++ b/ok.sh
@@ -185,6 +185,7 @@ if [[ $called == $0 ]]; then
     echo "arguments, if you need to customize (these can also be set via arguments/environment):"
     echo "  prompt <prompt> Use the supplied prompt (e.g. prompt '> ')"
     echo "  prompt_default  Prompt default when issueing running ok without arguments"
+    echo "  auto_show       Perform 'ok list-once' every time the prompt is shown (modifies \$PROMPT_COMMAND)"
     echo "  verbose         Enable verbose mode"
     echo "  quiet           Enable quiet mode"
     echo
@@ -193,15 +194,19 @@ else
     unset _OK_C_HEADING; unset _OK_C_NUMBER; unset _OK_C_COMMENT; unset _OK_C_COMMAND; unset _OK_C_PROMPT
     unset _OK_PROMPT; unset _OK_PROMPT_DEFAULT; unset _OK_VERBOSE; unset _OK__LAST_PWD
     # Process some installation helpers
+    re_list_once=$'ok list-once'
     while (( $# > 0 )) ; do
         case $1 in
             prompt) if [[ $# -ge 2 ]]; then export _OK_PROMPT=$2; shift; else echo "the prompt argument needs the actual prompt as 2nd argument"; fi;;
             prompt_default) export _OK_PROMPT_DEFAULT=1;;
             verbose)        export _OK_VERBOSE=2;;
             quiet)          export _OK_VERBOSE=0;;
+            auto_show)      if [[ ! $PROMPT_COMMAND =~ $re_list_once ]]; then export PROMPT_COMMAND="$PROMPT_COMMAND
+$re_list_once"; fi;;
             *) echo "Ignoring unknown argument '$1'";;
         esac
         shift
     done
+    unset re_list_once
 fi
 unset called

--- a/ok.sh
+++ b/ok.sh
@@ -3,7 +3,7 @@
 called=$_
 
 #basically, get the absolute path of this script (handy for loads of things)
-pushd "$(dirname "${BASH_SOURCE[@]}")" > /dev/null;
+pushd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null;
 _OK__PATH_TO_ME=$(pwd)
 popd > /dev/null;
 

--- a/ok.sh
+++ b/ok.sh
@@ -108,7 +108,8 @@ environment variables (for internal use):
     if [ -z ${_OK_PROMPT+x} ];    then local PROMPT="$ ";               else local PROMPT=$_OK_PROMPT;       fi
     if [ -z ${_OK_VERBOSE+x} ];   then local verbose=1;                 else local verbose=$_OK_VERBOSE;     fi
 
-    # handle command line arguments first
+    # handle command line arguments now
+    local args="ok $@"              #preserve all arguments ($0 is '-bash', so hard-code function name)
     local re_is_num='^[1-9][0-9]*$' #numbers starting with "0" would be octal, and nobody knows those (also: sed on Linux complains about line "0")...
     local cmd=list
     local line_nr=0
@@ -151,6 +152,9 @@ environment variables (for internal use):
                     local re_num_begin='^[1-9][0-9]*($| )' # You can enter arguments at the ok-prompt too, hence different regex
                     read -p "${C_PROMPT}${PROMPT}${C_NC}" prompt_input
                     if [[ $prompt_input =~ $re_num_begin ]]; then
+                        #save command to history first
+                        history -s $args $prompt_input
+                        #execute command
                         eval _ok_cmd_run $prompt_input || return $?
                     else
                         if [[ $verbose -ge 2 ]]; then

--- a/ok.sh
+++ b/ok.sh
@@ -46,7 +46,7 @@ environment variables (other configuration):
   _OK_PROMPT_DEFAULT Setting ($l) if the prompt is default shown. 1=use command list-prompt when issuing no command, otherwise use list.
   _OK_VERBOSE        Level ($v) of feedback ok provides. 0=quiet, 1=normal, 2=verbose. Defaults to 1. Can be overriden with --verbose or --quiet.
 environment variables (for internal use):
-  _OK__LAST_PWD      Remember the path ($_OK_LAST_PWD) that was last listed, for use with the list-once command.
+  _OK__LAST_PWD      Remember the path ($_OK__LAST_PWD) that was last listed, for use with the list-once command.
   _OK__PATH_TO_ME    The path ($_OK__PATH_TO_ME) to the location of this script.\n"
         fi
         if [[ -n $1 ]]; then


### PR DESCRIPTION
* now `ok.sh` will provide a tip, instead of silently doing nothing
* the list-command is now default again; list-prompt can be configured to be default too
* the list-numbers are now right aligned
* list-prompt saves the entered data to the history (this saves a lot of frustration)
* added some installation helpers (issue `./ok.sh` for help on this)