### PR TITLE
Suggest .bashrc instead of .profile for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ And you can pass simple arguments to the commands. For example:
 
 Clone the git-repository (`git clone https://github.com/secretGeek/ok-bash.git`), so you can easily update it with a `git pull`.
 
-Install it by "." (i.e. dot-sourcing) the "ok.sh" script from your `~/.profile` (or your favorite initialization script), e.g:
+Install it by "." (i.e. dot-sourcing) the "ok.sh" script from your `~/.bashrc` (or your favorite initialization script), e.g:
 
     . ~/path/to/ok-bash/ok.sh
 


### PR DESCRIPTION
On my system (ubuntu), sourcing `.ok.sh` within `.profile` instead of `.bashrc` displays an error when loading into my user session. Souncing from `.bashrc` instead solves the issue.

See attached photo for exact error
![2021-06-13 18 32 35](https://user-images.githubusercontent.com/1246794/121815512-25115700-cc77-11eb-92a7-d9b6fea811c5.jpg)
