### PR TITLE
Fix zsh sourcing detection

### DIFF
--- a/ok.sh
+++ b/ok.sh
@@ -280,8 +280,9 @@ environment variables (for internal use):
 }
 
 is_sourced=""
-if [ "${ZSH_ARGZERO:+IS_SET}" = "IS_SET" ]; then
-    if [ "$ZSH_ARGZERO" = "zsh" ]; then
+if [ -n "$ZSH_VERSION" ]; then
+    # For zsh, check if script name matches $0
+    if [[ "${(%):-%N}" == *"ok.sh" ]]; then
         is_sourced="yes_indeed"
     fi
 else 


### PR DESCRIPTION
In macOS with zsh, the startup help message is always shown. 

Claude: The issue is in the zsh detection code. In zsh, $0 doesn't work the same way as bash for detecting if a script is sourced. Let's patch it to fix zsh sourcing detection.